### PR TITLE
Hotfix

### DIFF
--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -73,6 +73,7 @@ class PvExcessControl:
     # TODO:
     #  - What about other domains than switches? Enable use of other domains (e.g. light, ...)
     #  - Make min_excess_power configurable via blueprint
+    #  - Implement updating of pv sensors history more often. E.g. every 10secs, and averaging + adding to history every minute.
     instances = {}
     trigger = None
     export_power = None
@@ -198,8 +199,9 @@ class PvExcessControl:
                         excess_amps = round(avg_excess_power / (PvExcessControl.grid_voltage * inst.phases), 1)
                         prev_amps = _get_num_state(inst.appliance_current_set_entity, return_on_error=inst.min_current)
                         amps = max(inst.min_current, min(excess_amps, inst.max_current))
-                        number.set_value(entity_id=inst.appliance_current_set_entity, value=amps)
-                        log.info(f'{log_prefix} Setting dynamic current appliance from {prev_amps} to {amps} A per phase.')
+                        if amps > prev_amps:
+                            number.set_value(entity_id=inst.appliance_current_set_entity, value=amps)
+                            log.info(f'{log_prefix} Setting dynamic current appliance from {prev_amps} to {amps} A per phase.')
                         diff_power = (amps-prev_amps) * PvExcessControl.grid_voltage * inst.phases
                         # "restart" history by subtracting power difference from each history value within the specified time frame
                         self._adjust_pwr_history(inst, -diff_power)
@@ -265,7 +267,10 @@ class PvExcessControl:
                                 # "restart" history by adding defined power to each history value within the specified time frame
                                 self._adjust_pwr_history(inst, diff_power)
                             else:
-                                # current cannot be reduced, turn off appliance
+                                # current cannot be reduced
+                                # set current to 0
+                                number.set_value(entity_id=inst.appliance_current_set_entity, value=0)
+                                # turn off appliance
                                 power_consumption = self.switch_off(inst, log_prefix)
                                 if power_consumption != 0:
                                     prev_consumption_sum += power_consumption

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -202,9 +202,9 @@ class PvExcessControl:
                         if amps > prev_amps:
                             number.set_value(entity_id=inst.appliance_current_set_entity, value=amps)
                             log.info(f'{log_prefix} Setting dynamic current appliance from {prev_amps} to {amps} A per phase.')
-                        diff_power = (amps-prev_amps) * PvExcessControl.grid_voltage * inst.phases
-                        # "restart" history by subtracting power difference from each history value within the specified time frame
-                        self._adjust_pwr_history(inst, -diff_power)
+                            diff_power = (amps-prev_amps) * PvExcessControl.grid_voltage * inst.phases
+                            # "restart" history by subtracting power difference from each history value within the specified time frame
+                            self._adjust_pwr_history(inst, -diff_power)
 
                 else:
                     # check if appliance can be switched on


### PR DESCRIPTION
**Fixes**

- Hotfix: Wrong power history adjustment corrected (introduced in last PR)
- Ensure that current of dyn. appl. is set to 0 when switching off

