### PR TITLE
Implemented solar forecasts to further optimize excess usage

### DIFF
--- a/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
+++ b/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
@@ -1,6 +1,11 @@
 blueprint:
   name: INVENTOCASA - PV Excess Optimizer
-  description: "Automatically control your appliances based on excess power from your solar system"
+  description: "### **PV EXCESS OPTIMIZER**\nAutomatically control your appliances based on excess power from your solar system <br> <br>
+  &rarr; Remember to read the **[README](https://github.com/InventoCasa/ha-advanced-blueprints/blob/main/PV_Excess_Control/README.md)** for prerequisites and installation instructions\n
+  &rarr; If you need help, head over to the [thread in the HA community forum](https://community.home-assistant.io/t/pv-solar-excess-optimizer-auto-control-appliances-wallbox-dish-washer-heatpump-based-on-excess-solar-power/552677)\n
+  &rarr; Bugs and feature requests can be created directly on the [GitHub repository](https://github.com/InventoCasa/ha-advanced-blueprints)\n\n
+  &rarr; If you want to say *thank you* for this blueprint, you can do so by buying me a [*virtual coffee*](https://www.buymeacoffee.com/henrikIC)\n <br><br>"
+
   domain: automation
   input:
     automation_id:
@@ -87,18 +92,47 @@ blueprint:
         entity:
           domain: sensor
           multiple: false
+
     min_home_battery_level:
-      name: "Minimum home battery level"
-      description: "Minimum power level (in percent) of your home battery, before starting to switch on your appliance.\n(If `home_battery_level < min_home_battery_level` -> Export Power will be considered for appliance switching)\n
-      (If `home_battery_level >= min_home_battery_level` -> PV Power will be considered for appliance switching)\n\n
-      **[NOTE]**\nOnly relevant if your solar system is coupled with a battery."
-      default: 50
+      name: "Minimum home battery level (end of day)"
+      description: "Minimum desired power level (in percent) of your home battery (end of day)\n\n
+      **[WARNING]\nThis sensor must be the same for all your created automations based on this blueprint!**\n\n
+      **[NOTE]**\n
+      - If your solar system is not coupled with a battery, this field will be ignored.\n
+      - *If you also specify **solar production forecast***, the script will optimize your PV excess consumption right away and ensure that the specified *minimum home battery level* is reached at the **end of the day**.\n
+      - *If you **do not** specify solar production forecast*, the home battery will be charged to the specified level *before* switching on appliances."
+      default: 100
       selector:
         number:
           min: 0
           max: 100
           step: 5
           unit_of_measurement: "%"
+
+    home_battery_capacity:
+      name: "Home battery capacity"
+      description: "The usable capacity (in kWh) of your home battery\n\n
+      **[WARNING]\nThis sensor must be the same for all your created automations based on this blueprint!**\n\n
+      **[NOTE]**\n
+      - If your solar system is not coupled with a battery, this field will be ignored."
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 60
+          step: 0.5
+          unit_of_measurement: kWh
+
+    solar_production_forecast:
+      name: "*Remaining* solar production forecast (Solcast)"
+      description: "Sensor which represents the **remaining solar production forecast** for the current day (in kWh). Will be used to ensure the specified *minimum home battery level* is reached at the end of the day.\n\n
+      **[WARNING]\nThis sensor must be the same for all your created automations based on this blueprint!**\n\n
+      **[NOTE]**\nIf your solar system is not coupled with a battery, leave this field empty"
+      default:
+      selector:
+        entity:
+          domain: sensor
+          multiple: false
 
 
     appliance_switch:
@@ -225,3 +259,5 @@ action:
       appliance_on_only: !input appliance_on_only
       grid_voltage: !input grid_voltage
       import_export_power: !input import_export_power
+      home_battery_capacity: !input home_battery_capacity
+      solar_production_forecast: !input solar_production_forecast


### PR DESCRIPTION
- Implemented _home battery capacity_ sensor
- Implemented _remaining solar forecast_ sensor
- If the _remaining solar forecast_ and the _home battery capacity_ are given, the optimizer will now ensure that the home battery reaches the specified _minimum home battery level_ at the end of the day.
  - This also means, that appliances can turn on way earlier as long as the expected remaining solar production is higher than the remaining non-charged battery capacity