### PR TITLE
Additional appliance domains, Bugfixes

### DIFF
--- a/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
+++ b/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
@@ -73,7 +73,7 @@ blueprint:
     import_export_power:
       name: "Combined Import/Export Power"
       description: "Sensor which contains **both**, your current **import power from the grid** (*positive* values) and your current **export power to the grid** in watts (*negative* values).\nFor best results, this sensor should be updated at least every minute.\n\n 
-      **[WARNING]\nThis sensor must be the same for all your created automations based on this blueprint!**\nThis sensor must be specified **only when you cannot provide both the *Export Power* and *Load Power* sensor.** This is normally the case when you have a standard inverter without battery.\n\n
+      **[WARNING]\nDo not use this sensor when you have a hybrid inverter with battery. Otherwise the script cannot detect when your battery is discharging to compensate for a load.**\n\n
       **[NOTE]**\nThis is typically the value your household energy meter shows."
       default:
       selector:
@@ -136,11 +136,10 @@ blueprint:
 
 
     appliance_switch:
-      name: "Appliance On/Off switch"
-      description: "Switch to turn the appliance on/off."
+      name: "Appliance Entity"
+      description: "Entity to control the appliance (e.g. switch entity, climate entity, light entity, ...)"
       selector:
         entity:
-          domain: switch
           multiple: false
     appliance_switch_interval:
       name: "Appliance On/Off switch interval"

--- a/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
+++ b/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
@@ -74,6 +74,7 @@ blueprint:
       name: "Combined Import/Export Power"
       description: "Sensor which contains **both**, your current **import power from the grid** (*positive* values) and your current **export power to the grid** in watts (*negative* values).\nFor best results, this sensor should be updated at least every minute.\n\n
       **[WARNING]\nThis sensor must be the same for all your created automations based on this blueprint!**\nThis sensor must be specified **only when you cannot provide both the *Export Power* and *Load Power* sensor.** This is normally the case when you have a standard inverter without battery.\n\n
+      **[WARNING]\nDo not use this sensor when you have a hybrid inverter with battery. Otherwise the script cannot detect when your battery is discharging to compensate for a load!**\n\n
       **[NOTE]**\nThis is typically the value your household energy meter shows."
       default:
       selector:

--- a/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
+++ b/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
@@ -72,8 +72,8 @@ blueprint:
 
     import_export_power:
       name: "Combined Import/Export Power"
-      description: "Sensor which contains **both**, your current **import power from the grid** (*positive* values) and your current **export power to the grid** in watts (*negative* values).\nFor best results, this sensor should be updated at least every minute.\n\n 
-      **[WARNING]\nDo not use this sensor when you have a hybrid inverter with battery. Otherwise the script cannot detect when your battery is discharging to compensate for a load.**\n\n
+      description: "Sensor which contains **both**, your current **import power from the grid** (*positive* values) and your current **export power to the grid** in watts (*negative* values).\nFor best results, this sensor should be updated at least every minute.\n\n
+      **[WARNING]\nThis sensor must be the same for all your created automations based on this blueprint!**\nThis sensor must be specified **only when you cannot provide both the *Export Power* and *Load Power* sensor.** This is normally the case when you have a standard inverter without battery.\n\n
       **[NOTE]**\nThis is typically the value your household energy meter shows."
       default:
       selector:

--- a/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
+++ b/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
@@ -1,6 +1,11 @@
 blueprint:
   name: INVENTOCASA - PV Excess Optimizer
-  description: "Automatically control your appliances based on excess power from your solar system"
+  description: "### **PV EXCESS OPTIMIZER**\nAutomatically control your appliances based on excess power from your solar system <br> <br>
+  &rarr; Remember to read the **[README](https://github.com/InventoCasa/ha-advanced-blueprints/blob/main/PV_Excess_Control/README.md)** for prerequisites and installation instructions\n
+  &rarr; If you need help, head over to the [thread in the HA community forum](https://community.home-assistant.io/t/pv-solar-excess-optimizer-auto-control-appliances-wallbox-dish-washer-heatpump-based-on-excess-solar-power/552677)\n
+  &rarr; Bugs and feature requests can be created directly on the [GitHub repository](https://github.com/InventoCasa/ha-advanced-blueprints)\n\n
+  &rarr; If you want to say *thank you* for this blueprint, you can do so by buying me a [*virtual coffee*](https://www.buymeacoffee.com/henrikIC)\n <br><br>"
+
   domain: automation
   input:
     automation_id:
@@ -87,18 +92,47 @@ blueprint:
         entity:
           domain: sensor
           multiple: false
+
     min_home_battery_level:
-      name: "Minimum home battery level"
-      description: "Minimum power level (in percent) of your home battery, before starting to switch on your appliance.\n(If `home_battery_level < min_home_battery_level` -> Export Power will be considered for appliance switching)\n
-      (If `home_battery_level >= min_home_battery_level` -> PV Power will be considered for appliance switching)\n\n
-      **[NOTE]**\nOnly relevant if your solar system is coupled with a battery."
-      default: 50
+      name: "Minimum home battery level (end of day)"
+      description: "Minimum desired power level (in percent) of your home battery (end of day)\n\n
+      **[WARNING]\nThis sensor must be the same for all your created automations based on this blueprint!**\n\n
+      **[NOTE]**\n
+      - If your solar system is not coupled with a battery, this field will be ignored.\n
+      - *If you also specify **solar production forecast***, the script will optimize your PV excess consumption right away and ensure that the specified *minimum home battery level* is reached at the **end of the day**.\n
+      - *If you **do not** specify solar production forecast*, the home battery will be charged to the specified level *before* switching on appliances."
+      default: 100
       selector:
         number:
           min: 0
           max: 100
           step: 5
           unit_of_measurement: "%"
+
+    home_battery_capacity:
+      name: "Home battery capacity"
+      description: "The usable capacity (in kWh) of your home battery\n\n
+      **[WARNING]\nThis sensor must be the same for all your created automations based on this blueprint!**\n\n
+      **[NOTE]**\n
+      - If your solar system is not coupled with a battery, this field will be ignored."
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 60
+          step: 0.5
+          unit_of_measurement: kWh
+
+    solar_production_forecast:
+      name: "*Remaining* solar production forecast (Solcast)"
+      description: "Sensor which represents the **remaining solar production forecast** for the current day (in kWh). Will be used to ensure the specified *minimum home battery level* is reached at the end of the day.\n\n
+      **[WARNING]\nThis sensor must be the same for all your created automations based on this blueprint!**\n\n
+      **[NOTE]**\nIf your solar system is not coupled with a battery, leave this field empty"
+      default:
+      selector:
+        entity:
+          domain: sensor
+          multiple: false
 
 
     appliance_switch:
@@ -225,3 +259,5 @@ action:
       appliance_on_only: !input appliance_on_only
       grid_voltage: !input grid_voltage
       import_export_power: !input import_export_power
+      home_battery_capacity: !input home_battery_capacity
+      solar_production_forecast: !input solar_production_forecast

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -425,8 +425,6 @@ class PvExcessControl:
             else:
                 power_consumption = _get_num_state(inst.actual_power)
             log.debug(f'{inst.log_prefix} Current power consumption: {power_consumption} W')
-            # set current to 0
-            number.set_value(entity_id=inst.appliance_current_set_entity, value=0)
             # switch off appliance
             _turn_off(inst.appliance_switch)
             log.info(f'{inst.log_prefix} Switched off appliance.')

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -151,9 +151,11 @@ class PvExcessControl:
     # PV Excess history (PV power minus load power)
     pv_history = [0]*60
     # Minimum excess power in watts. If the average min_excess_power at the specified appliance switch interval is greater than the actual
-    # excess power, the appliance with the lowest priority will be shut off. WARNING: Setting this too low (e.g. to zero) could have the
-    # consequence that your last running appliance will not be switched off.
-    min_excess_power = 10
+    #  excess power, the appliance with the lowest priority will be shut off.
+    #  NOTE: Should be slightly negative, to compensate for inaccurate power corrections
+    #  WARNING: Do net set this to more than 0, otherwise some devices with dynamic current control will abruptly get switched off in some
+    #  situations.
+    min_excess_power = -10
 
 
     def __init__(self, automation_id, appliance_priority, export_power, pv_power, load_power, home_battery_level,

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -22,19 +22,17 @@ def _get_state(entity_id: str) -> Union[str, None]:
         log.error(f'Could not get state from entity {entity_id}: {e}')
         return None
 
-    match domain:
-        case 'climate':
-            if entity_state.lower() in ['heat', 'cool', 'boost']:
-                return 'on'
-            elif entity_state == 'off':
-                return entity_state
-            else:
-                log.error(f'Entity state not supported: {entity_state}')
-                return None
-        case 'switch':
+    if domain == 'climate':
+        if entity_state.lower() in ['heat', 'cool', 'boost', 'on']:
+            return 'on'
+        elif entity_state == 'off':
             return entity_state
-        case _:
-            log.error(f'Domain not supported: {domain}')
+        else:
+            log.error(f'Entity state not supported: {entity_state}')
+            return None
+
+    else:
+        return entity_state
 
 
 def _turn_off(entity_id: str):


### PR DESCRIPTION
- Implemented handling of different entity domains for appliance_switch entity.
Besides normal switches, from now on all other entity domains which have a turn_on and turn_off action are also supported:
  - climate entities
  - light entities
  - input_boolean entities
  - automation entities
  - ...

- fixed issue that appliances abruptly get switched off, because of a too-high min_excess_power value
- fixed issue that current of dyn. curr. appliance gets set to zero when switching the appliance off
- added warning regarding the use of the combined import/export power sensor: Do not use if you have a hybrid inverter with battery!
