### PR TITLE
Adds Support for Export Limited PV systems

### DIFF
--- a/PV_Excess_Control/README.md
+++ b/PV_Excess_Control/README.md
@@ -13,11 +13,17 @@ If you like my work, you can support me here:\
 :white_check_mark: Define min. and max. current for appliances supporting dynamic current control\
 :white_check_mark: Supports one- and three-phase appliances\
 :white_check_mark: Supports *Only-Switch-On* devices like washing machines or dishwashers
+:white_check_mark: Supports *Export Limited PV generation systems* where excess power to the grid is limited by the power provider.
 
 
 ## Prerequisites
 - A working installation of [pyscript](https://github.com/custom-components/pyscript) (can be installed via [HACS](https://hacs.xyz/))
 - (*Optional:* A working installation of solcast (can be installed via [HACS custom repository](https://github.com/oziee/ha-solcast-solar))
+- *Optional:* A working installation of forecast.solar, this is used by PV systems that are export limited.  
+  - Enable the "Estimate power available this hour" entity as this is disabled by default within the forecast.solar integration (I've had better success with the next hour estimate, your milage may vary, so experiment and find what works best for you)
+  - The forecast sensor must be in W.
+  - If you have multiple panel arrays, combine each of the forecasts into a single sensor and use the combined sensor.
+  - Depending on how much you are export limited by the power provider, there is the pyscript code variable "pv_forecast_threshold" adjust this threshold to cutover to real excess power export as reported by your system, defaults to 1000W 
 - Home Assistant v2023.1 or greater
 - Access to the following values from your hybrid PV inverter:
   - Export power

--- a/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
+++ b/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
@@ -49,7 +49,7 @@ blueprint:
           multiple: false
 
     pv_power_forecast:
-      name: "Estimate of PV power for the current hour forecast (Solcast)"
+      name: "Estimate of PV power for the current hour forecast (Forecast.Solar)"
       description: "Sensor which represents the **estimate of the PV power generated** for the current hour (in W). Will be used to calculate excess power when export limiting is in place by your power provider.\n\n
       **[WARNING]**\n
       - **This sensor must be the same for all your created automations based on this blueprint!**\n\n

--- a/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
+++ b/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
@@ -47,6 +47,21 @@ blueprint:
         entity:
           domain: sensor
           multiple: false
+
+    pv_power_forecast:
+      name: "Estimate of PV power for the current hour forecast (Solcast)"
+      description: "Sensor which represents the **estimate of the PV power generated** for the current hour (in W). Will be used to calculate excess power when export limiting is in place by your power provider.\n\n
+      **[WARNING]**\n
+      - **This sensor must be the same for all your created automations based on this blueprint!**\n\n
+      **[NOTE]**\n
+      - If you are not export limited by your power provider leave this field empty"
+      default:
+      selector:
+        entity:
+          domain: sensor
+          multiple: false
+
+          
     export_power:
       name: "Export Power"
       description: "Sensor which contains your current **export power to the grid** in watts.\nMust not be negative! For best results, this sensor should be updated at least every minute.\n\n 
@@ -293,3 +308,4 @@ action:
       home_battery_capacity: !input home_battery_capacity
       solar_production_forecast: !input solar_production_forecast
       appliance_once_only: !input appliance_once_only
+      pv_power_forecast: !input pv_power_forecast

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -412,7 +412,7 @@ class PvExcessControl:
                 export_limited = True
                 pv_pow = int(_get_num_state(PvExcessControl.pv_power))  # Current pv power being generated
                 pv_forecast = int(_get_num_state(PvExcessControl.pv_power_forecast)) # solcast hourly forecast for right now
-                estimate_pv_pow = abs(min(0,pv_forecast - pv_power))
+                estimate_pv_pow = abs(min(0,pv_forecast - pv_pow))
                 log.debug(f'Export Limiting estimated excess power: {estimate_pv_pow}')
             if PvExcessControl.import_export_power:
                 # Calc values based on combined import/export power sensor
@@ -427,7 +427,7 @@ class PvExcessControl:
         except Exception as e:
             log.error(f'Could not update Export/PV history!: {e}')
         else:
-            if export_limiting:
+            if export_limited:
                 excess_pwr = excess_pwr + estimate_pv_pow
                 log.debug(f'Export Limiting estimated excess power: {excess_pwr}')
             PvExcessControl.export_history_buffer.append(export_pwr)


### PR DESCRIPTION
Uses forecast.solar integration 


example:  I'm limited to 1500W export limit on my 15KW system, so at the most I can ever export on my 15KW system is 1500w, as such, I never get over the control thresholds to charge my Tesla and will always sit on the lowest amps

Implementing the estimation of PV generation available right now using the forecast.solar integration allows full potential of control a seen in the screenshot that shows working implementation of this PR, morning is export limited, while when I enabled you can see full tracking occurring at full output that the PVs are generating for the time of day

<img width="556" alt="image" src="https://github.com/InventoCasa/ha-advanced-blueprints/assets/4160293/00fc0dce-fff9-49e2-bef4-8c45159787bf">

closes #47 