### PR TITLE
switch on high prio devices, even if they only use a fraction of the excess power.

### DIFF
--- a/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
+++ b/PV_Excess_Control/blueprints/automation/pv_excess_control.yaml
@@ -17,12 +17,14 @@ blueprint:
         text:
     appliance_priority:
       name: "Appliance priority"
-      description: "Appliances with a higher number are prioritized compared to appliances with a lower number."
+      description: "Appliances with a higher number are prioritized compared to appliances with a lower number.\n\n
+      If the priority is greater than 1000 this appliance will be switched on, even if the excess power is not 
+      sufficient for 100% of the needed power
       default: 1
       selector:
         number:
           min: 1
-          max: 1000
+          max: 2000
           mode: box
           unit_of_measurement: "Priority level"
 

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -240,7 +240,8 @@ class PvExcessControl:
             # Sanity check
             if not self.sanity_check():
                 return on_time
-                
+            if not PvExcessControl.instances:  
+                return on_time     
             # execute only if this the first instance of the dictionary (avoid two automations acting)
             #log.info(f'{self.log_prefix} I am around.')
             first_item = next(iter(PvExcessControl.instances.values()))

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -240,7 +240,9 @@ class PvExcessControl:
             # Sanity check
             if (not PvExcessControl.instances) or (not self.sanity_check()):
                 return on_time
-
+                
+            # execute only if this the first instance of the dictionary (avoid two automations acting)
+            #log.info(f'{self.log_prefix} I am around.')
             first_item = next(iter(PvExcessControl.instances.values()))
             if first_item["instance"] != self:
                 return on_time                
@@ -276,7 +278,6 @@ class PvExcessControl:
                     log.debug(f'{log_prefix} Home battery charge is sufficient ({home_battery_level}/{PvExcessControl.min_home_battery_level} %)'
                               f' OR remaining solar forecast is higher than remaining capacity of home battery. '
                               f'Calculated average excess power based on >> solar power - load power <<: {avg_excess_power} W')
-                    #          f' inst.appliance_switch_interval {inst.appliance_switch_interval}'
 
                 else:
                     # home battery charge is not yet high enough OR battery force charge is necessary.

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -238,10 +238,9 @@ class PvExcessControl:
         @time_trigger('period(now, 10s)')
         def on_time():
             # Sanity check
-            if not self.sanity_check():
+            if not (PvExcessControl.instances or self.sanity_check()):
                 return on_time
-            if not PvExcessControl.instances:  
-                return on_time     
+   
             # execute only if this the first instance of the dictionary (avoid two automations acting)
             #log.info(f'{self.log_prefix} I am around.')
             first_item = next(iter(PvExcessControl.instances.values()))

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -240,9 +240,7 @@ class PvExcessControl:
             # Sanity check
             if (not PvExcessControl.instances) or (not self.sanity_check()):
                 return on_time
-   
-            # execute only if this the first instance of the dictionary (avoid two automations acting)
-            #log.info(f'{self.log_prefix} I am around.')
+
             first_item = next(iter(PvExcessControl.instances.values()))
             if first_item["instance"] != self:
                 return on_time                
@@ -274,16 +272,17 @@ class PvExcessControl:
                 if home_battery_level >= PvExcessControl.min_home_battery_level or not self._force_charge_battery():
                     # home battery charge is high enough to direct solar power to appliances, if solar power is higher than load power
                     # calc avg based on pv excess (solar power - load power) according to specified window
-                    avg_excess_power = int(sum(PvExcessControl.pv_history[-inst.appliance_switch_interval:]) / inst.appliance_switch_interval)
+                    avg_excess_power = int(sum(PvExcessControl.pv_history[-inst.appliance_switch_interval:]) / min([1,inst.appliance_switch_interval]))
                     log.debug(f'{log_prefix} Home battery charge is sufficient ({home_battery_level}/{PvExcessControl.min_home_battery_level} %)'
                               f' OR remaining solar forecast is higher than remaining capacity of home battery. '
                               f'Calculated average excess power based on >> solar power - load power <<: {avg_excess_power} W')
+                    #          f' inst.appliance_switch_interval {inst.appliance_switch_interval}'
 
                 else:
                     # home battery charge is not yet high enough OR battery force charge is necessary.
                     # Only use excess power (which would otherwise be exported to the grid) for appliance
                     # calc avg based on export power history according to specified window
-                    avg_excess_power = int(sum(PvExcessControl.export_history[-inst.appliance_switch_interval:]) / inst.appliance_switch_interval)
+                    avg_excess_power = int(sum(PvExcessControl.export_history[-inst.appliance_switch_interval:]) / min([1,inst.appliance_switch_interval]))
                     log.debug(f'{log_prefix} Home battery charge is not sufficient ({home_battery_level}/{PvExcessControl.min_home_battery_level} %), '
                               f'OR remaining solar forecast is lower than remaining capacity of home battery. '
                               f'Calculated average excess power based on >> export power <<: {avg_excess_power} W')
@@ -315,7 +314,8 @@ class PvExcessControl:
                         log.warning(f'{log_prefix} Appliance state (={_get_state(inst.appliance_switch)}) is neither ON nor OFF. '
                                     f'Assuming OFF state.')
                     defined_power = inst.defined_current * PvExcessControl.grid_voltage * inst.phases
-                    if avg_excess_power >= defined_power:
+
+                    if avg_excess_power >= defined_power or (inst.appliance_priority > 500 and avg_excess_power > 0):
                         log.debug(f'{log_prefix} Average Excess power is high enough to switch on appliance.')
                         if inst.switch_interval_counter >= inst.appliance_switch_interval:
                             self.switch_on(inst)
@@ -344,7 +344,15 @@ class PvExcessControl:
 
                 # -------------------------------------------------------------------
                 if _get_state(inst.appliance_switch) == 'on':
-                    if avg_excess_power < PvExcessControl.min_excess_power:
+                    # check if inst.appliance_priority > 500 and switching of will cause excess. In that case keep it on
+                    if inst.appliance_priority > 500:
+                        if inst.actual_power is None:
+                            allowed_excess_power_consumption = inst.defined_current * PvExcessControl.grid_voltage * inst.phases
+                        else:
+                            allowed_excess_power_consumption = _get_num_state(inst.actual_power)
+                    else:
+                        allowed_excess_power_consumption = 0
+                    if avg_excess_power < PvExcessControl.min_excess_power - allowed_excess_power_consumption:
                         log.debug(f'{log_prefix} Average Excess Power ({avg_excess_power} W) is less than minimum excess power '
                                   f'({PvExcessControl.min_excess_power} W).')
 
@@ -372,6 +380,11 @@ class PvExcessControl:
                             else:
                                 # current cannot be reduced
                                 # turn off appliance
+                                # todo: check if inst.appliance_priority > 500 and switching of will cause excess 
+                                #  if inst.actual_power is None:
+                                #    power_consumption = inst.defined_current * PvExcessControl.grid_voltage * inst.phases
+                                #  else:
+                                #    power_consumption = _get_num_state(inst.actual_power)
                                 power_consumption = self.switch_off(inst)
                                 if power_consumption != 0:
                                     prev_consumption_sum += power_consumption

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -238,7 +238,7 @@ class PvExcessControl:
         @time_trigger('period(now, 10s)')
         def on_time():
             # Sanity check
-            if not (PvExcessControl.instances or self.sanity_check()):
+            if (not PvExcessControl.instances) or (not self.sanity_check()):
                 return on_time
    
             # execute only if this the first instance of the dictionary (avoid two automations acting)

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -381,11 +381,6 @@ class PvExcessControl:
                             else:
                                 # current cannot be reduced
                                 # turn off appliance
-                                # todo: check if inst.appliance_priority > 500 and switching of will cause excess 
-                                #  if inst.actual_power is None:
-                                #    power_consumption = inst.defined_current * PvExcessControl.grid_voltage * inst.phases
-                                #  else:
-                                #    power_consumption = _get_num_state(inst.actual_power)
                                 power_consumption = self.switch_off(inst)
                                 if power_consumption != 0:
                                     prev_consumption_sum += power_consumption

--- a/PV_Excess_Control/pyscript/pv_excess_control.py
+++ b/PV_Excess_Control/pyscript/pv_excess_control.py
@@ -316,7 +316,7 @@ class PvExcessControl:
                                     f'Assuming OFF state.')
                     defined_power = inst.defined_current * PvExcessControl.grid_voltage * inst.phases
 
-                    if avg_excess_power >= defined_power or (inst.appliance_priority > 500 and avg_excess_power > 0):
+                    if avg_excess_power >= defined_power or (inst.appliance_priority > 1000 and avg_excess_power > 0):
                         log.debug(f'{log_prefix} Average Excess power is high enough to switch on appliance.')
                         if inst.switch_interval_counter >= inst.appliance_switch_interval:
                             self.switch_on(inst)
@@ -345,8 +345,8 @@ class PvExcessControl:
 
                 # -------------------------------------------------------------------
                 if _get_state(inst.appliance_switch) == 'on':
-                    # check if inst.appliance_priority > 500 and switching of will cause excess. In that case keep it on
-                    if inst.appliance_priority > 500:
+                    # check if inst.appliance_priority > 1000 and switching of will cause excess. In that case keep it on
+                    if inst.appliance_priority > 1000:
                         if inst.actual_power is None:
                             allowed_excess_power_consumption = inst.defined_current * PvExcessControl.grid_voltage * inst.phases
                         else:


### PR DESCRIPTION
https://github.com/InventoCasa/ha-advanced-blueprints/issues/63

issue#63

Switch on high prio devices, even if they only use a fraction of the excess power, if prio > 500